### PR TITLE
Add support for primary prefixed ids and stubs to accomodate for this

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,34 @@ return [
      * The attribute name used to store prefixed ids on a model
      */
     'prefixed_id_attribute_name' => 'prefixed_id',
+
+    /*
+     * Using prefixed id's as primary id?
+     * If set to true, it's suggested to set 'prefixed_ids_attribute_name' to 'id'.
+     * Setting this to true sets Model's $incrementing to false by default.
+     */
+    'prefixed_id_is_primary' => false,
 ];
 ```
+
+When setting `prefixed_id_is_primary` to `true` it is suggested to also publish the custom stubs.
+
+```bash
+php artisan prefixedids:stubs
+```
+
+These stubs add the `Spatie\PrefixedIds\Models\Concerns\HasPrefixedId` trait to your models by default.
+
+They'll also adapt your migrations to include the following:
+
+```php
+Schema::create('your_models_table', function (Blueprint $table) {
+   $table->string('id')->primary();
+   $table->timestamps();
+});
+```
+
+Obviously, you can modify these stubs further.
 
 ## Usage
 

--- a/config/prefixed-ids.php
+++ b/config/prefixed-ids.php
@@ -5,4 +5,11 @@ return [
      * The attribute name used to store prefixed ids on a model
      */
     'prefixed_id_attribute_name' => 'prefixed_id',
+
+    /*
+     * Using prefixed id's as primary id?
+     * If set to true, it's suggested to set 'prefixed_ids_attribute_name' to 'id'.
+     * Setting this to true sets Model's $incrementing to false by default.
+     */
+    'prefixed_id_is_primary' => false,
 ];

--- a/src/Commands/StubsCommand.php
+++ b/src/Commands/StubsCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\PrefixedIds\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+
+class StubsCommand extends Command
+{
+    protected $signature = 'prefixedids:stubs';
+
+    protected $description = 'Publish stubs for primary prefixed IDs';
+
+    public function handle()
+    {
+        if (! is_dir($stubsPath = base_path('stubs'))) {
+            (new Filesystem)->makeDirectory($stubsPath);
+        }
+
+        file_put_contents(
+            $stubsPath.'/model.stub',
+            file_get_contents(__DIR__.'/../../stubs/model.stub')
+        );
+
+        file_put_contents(
+            $stubsPath.'/migration.create.stub',
+            file_get_contents(__DIR__.'/../../stubs/migration.create.stub')
+        );
+
+        $this->info('Custom stubs published successfully.');
+    }
+}

--- a/src/Models/Concerns/HasPrefixedId.php
+++ b/src/Models/Concerns/HasPrefixedId.php
@@ -18,6 +18,11 @@ trait HasPrefixedId
         });
     }
 
+    public function getIncrementing()
+    {
+        return !config('prefixed-ids.prefixed_id_is_primary');
+    }
+
     public function getPrefixedIdAttribute(): ?string
     {
         $attributeName = config('prefixed-ids.prefixed_id_attribute_name');

--- a/src/PrefixedIdsServiceProvider.php
+++ b/src/PrefixedIdsServiceProvider.php
@@ -5,6 +5,8 @@ namespace Spatie\PrefixedIds;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
+use Spatie\PrefixedIds\Commands\StubsCommand;
+
 class PrefixedIdsServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
@@ -12,5 +14,16 @@ class PrefixedIdsServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-prefixed-ids')
             ->hasConfigFile();
+
+        $this->registerCommands();
+    }
+
+    protected function registerCommands()
+    {
+        if (! $this->app->runningInConsole()) return;
+
+        $this->commands([
+            StubsCommand::class,        // prefixedids:stubs
+        ]);
     }
 }

--- a/stubs/migration.create.stub
+++ b/stubs/migration.create.stub
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class {{ class }} extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('{{ table }}', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('{{ table }}');
+    }
+}

--- a/stubs/model.stub
+++ b/stubs/model.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+use Spatie\PrefixedIds\Models\Concerns\HasPrefixedId;
+
+class {{ class }} extends Model
+{
+    use HasFactory, HasPrefixedId;
+}


### PR DESCRIPTION
This PR adds support for Prefixed IDs being the primary IDs.

Probably not perfect yet, but the start is there.

Setting `prefixed_id_is_primary` to `true` sets `$incrementing` to `false` for all Models using the `Spatie\PrefixedIds\Models\Concerns\HasPrefixedId` trait.

Added custom stubs for this as well. Publishing these will change the stubs to include the `HasPrefixedId` trait and update the migration to be `$table->string('id)->primary();`.

Reflected this in the README as well.

These stubs are publishable by running `php artisan prefixedids:stubs`.