### PR TITLE
Generate the unique IDs using a callabale function

### DIFF
--- a/src/Models/Concerns/HasPrefixedId.php
+++ b/src/Models/Concerns/HasPrefixedId.php
@@ -60,6 +60,7 @@ trait HasPrefixedId
 
     protected function getUniquePartForPrefixId(): string
     {
-        return str_replace('-', '', Str::uuid());
+        return PrefixedIds::getUniqueId();
+        /* return str_replace('-', '', Str::uuid()); */
     }
 }

--- a/src/PrefixedIds.php
+++ b/src/PrefixedIds.php
@@ -2,12 +2,15 @@
 
 namespace Spatie\PrefixedIds;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\PrefixedIds\Exceptions\NoPrefixedModelFound;
 
 class PrefixedIds
 {
     public static array $registeredModels = [];
+
+    public static null|object $uniqueId = null;
 
     public static function registerModels(array $registerModels): void
     {
@@ -60,5 +63,19 @@ class PrefixedIds
         }
 
         return null;
+    }
+
+    public static function getUniqueId(): string
+    {
+        if(!static::$uniqueId){
+            return str_replace('-', '', Str::uuid());
+        }
+
+        return call_user_func(static::$uniqueId);
+    }
+
+    public static function generateUniqueIdUsing(?callable $generateUsing): void
+    { 
+        static::$uniqueId = $generateUsing;
     }
 }

--- a/tests/PrefixedIdsTest.php
+++ b/tests/PrefixedIdsTest.php
@@ -21,6 +21,39 @@ class PrefixedIdsTest extends TestCase
     }
 
     /** @test */
+    public function it_generates_prefixed_id_using_method()
+    {
+        PrefixedIds::generateUniqueIdUsing(function(){
+            return 'foo';
+        });
+
+        $testModel = TestModel::create();
+
+        $this->assertSame('test_foo', $testModel->prefixed_id);
+
+        // reset the generate using Id function
+        PrefixedIds::generateUniqueIdUsing(null);
+    }
+
+    /** @test */
+    public function it_will_generate_unique_ids_using_method()
+    {
+        PrefixedIds::generateUniqueIdUsing(function(){
+            return rand();
+        });
+
+        $testModel = TestModel::create();
+        $secondTestModel = TestModel::create();
+
+        $this->assertStringStartsWith('test_', $testModel->prefixed_id);
+        $this->assertStringStartsWith('test_', $secondTestModel->prefixed_id);
+        $this->assertNotEquals($testModel->prefixed_id, $secondTestModel->prefixed_id);
+
+        // reset the generate using Id function
+        PrefixedIds::generateUniqueIdUsing(null);
+    }
+
+    /** @test */
     public function it_can_generated_a_prefixed_it()
     {
         $testModel = TestModel::create();


### PR DESCRIPTION
Per my discussion - https://github.com/spatie/laravel-prefixed-ids/discussions/13

I wanted the ability to customize the length of the unique IDs.  @freekmurze mentioned that it would be better to create a static method that calls a function to generate the unique IDs.  

You can now now customize the generated ids by doing the following:
```
PrefixedIds::generateUniqueIdUsing(function(){
    return rand();
});
```

This is completely optional, if the method is not used the library will continue using laravel's `Str::uuid()` method to generate the unique Ids.

@freekmurze - In your example you had `$model` variable included in the function I'm not sure what you meant on how that would be used.  Could you provide some more details on what you intended? 

Please let me know what can be improved.  Once you're happy with the pull request changes I can update the readme with usage and example. Thank you for the consideration.  
